### PR TITLE
update bundle name to add VNC viewer

### DIFF
--- a/source/clear-linux/get-started/virtual-machine-install/kvm.rst
+++ b/source/clear-linux/get-started/virtual-machine-install/kvm.rst
@@ -119,7 +119,7 @@ To add :abbr:`GDM (GNOME Display Manager)` to the |CL| VM, follow these steps:
 
      .. code-block:: console
 
-        # swupd bundle-add desktop-apps 
+        # swupd bundle-add desktop-apps-extras 
 
    * On Ubuntu\* 16.04 LTS Desktop:
 


### PR DESCRIPTION
Add "desktop-apps-extras" instead of "desktop-apps" to install VNC viewer on Clear Linux environment